### PR TITLE
Feat/paperdoll walk bounce

### DIFF
--- a/modules/game_attachedeffects/attachedeffects.lua
+++ b/modules/game_attachedeffects/attachedeffects.lua
@@ -1,4 +1,11 @@
+local function isPaperdollEffect(effect)
+    if not effect or not effect.getId then return false end
+    local id = effect:getId()
+    return id >= 10000 and id <= 120005
+end
+
 local function onAttach(effect, owner)
+    if isPaperdollEffect(effect) then return end
     if not AttachedEffectManager then return end
     local category, thingId = AttachedEffectManager.getDataThing(owner)
     local effDef = AttachedEffectManager.get(effect:getId())
@@ -14,6 +21,7 @@ local function onAttach(effect, owner)
 end
 
 local function onDetach(effect, oldOwner)
+    if isPaperdollEffect(effect) then return end
     if not AttachedEffectManager then return end
     local category, thingId = AttachedEffectManager.getDataThing(oldOwner)
     local effDef = AttachedEffectManager.get(effect:getId())
@@ -31,7 +39,9 @@ local function onOutfitChange(creature, outfit, oldOutfit)
     local ok, list = pcall(function() return creature:getAttachedEffects() end)
     if not ok or type(list) ~= 'table' then return end
     for _i, effect in pairs(list) do
-        if effect and effect.getId then
+        if isPaperdollEffect(effect) then
+            -- skip paperdoll overlays to avoid overriding dynamic offsets
+        elseif effect and effect.getId then
             local effDef = AttachedEffectManager.get(effect:getId())
             if effDef then
                 local cfg = AttachedEffectManager.getConfig(effect:getId(), ThingCategoryCreature, outfit.type)

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -102,6 +102,8 @@ local function applyOffsetsToActive(slot)
   local item = p:getInventoryItem(slot)
   local itemId = item and item:getId() or 0
   applyOffsetsForAllDirs(eff, slot, itemId)
+  local dir = p.getDirection and p:getDirection() or South
+  if eff.setDirection then eff:setDirection(dir) end
 end
 
 local function makeEffectId(slot, itemId, dirIdx)

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -114,6 +114,8 @@ end
 
 local function buildEffectConfig(slot, itemId)
   local cfg = { onTop = true, dirOffset = {} }
+  -- default gentle bounce while walking; controlled at runtime
+  cfg.bounce = { 0, 6, 800 }
   local map = getOffsetsFor(slot, itemId)
   if map then
     if map.N then cfg.dirOffset[North] = { map.N[1] or 0, map.N[2] or 0, map.N[3] and true or false } end
@@ -347,6 +349,7 @@ function controller:onGameStart()
         if cid and invisByCreature[cid] then return end
         local dirIdx = DIR_INDEX[direction] or nil
         if not dirIdx then return end
+        -- increase bounce during step start for a snappier feel
         for s, itemId in pairs(state.current) do
           local dirPaths = findDirectionalPNGs(s, itemId)
           if next(dirPaths) ~= nil then
@@ -359,6 +362,7 @@ function controller:onGameStart()
         if cid and invisByCreature[cid] then return end
         local dir = p.getDirection and p:getDirection() or South
         local dirIdx = DIR_INDEX[dir] or 2
+        -- sustain gentle bounce while auto-walking
         for s, itemId in pairs(state.current) do
           local dirPaths = findDirectionalPNGs(s, itemId)
           if next(dirPaths) ~= nil then

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -44,7 +44,8 @@ local invisByCreature = {}
 local OFFSETS = nil
 local OFFSETS_PATH = "/settings/paperdoll_offsets.json"
 local DIR_ALIAS = { N = North, E = East, S = South, W = West }
-local DIR_TO_KEY = { [North] = 'N', [East] = 'E', [South] = 'S', [West] = 'W' }
+-- Ensure both enum constants and raw numeric directions resolve
+local DIR_TO_KEY = { [North] = 'N', [East] = 'E', [South] = 'S', [West] = 'W', [0]='N', [1]='E', [2]='S', [3]='W' }
 
 local function loadOffsets()
   if OFFSETS then return OFFSETS end
@@ -365,6 +366,8 @@ function paperdoll_nudge_body(dirKey, dx, dy)
   if p then
     local dir = p.getDirection and p:getDirection() or South
     local dirIdx = DIR_INDEX[dir] or 2
+    -- re-apply offsets directly to active effect to avoid manager resets
+    applyOffsetsToActive(InventorySlotBody)
     local item = p:getInventoryItem(InventorySlotBody)
     if item then
       local paths = findDirectionalPNGs(InventorySlotBody, item:getId())
@@ -387,6 +390,7 @@ function paperdoll_nudge_head(dirKey, dx, dy)
   if p then
     local dir = p.getDirection and p:getDirection() or South
     local dirIdx = DIR_INDEX[dir] or 2
+    applyOffsetsToActive(InventorySlotHead)
     local item = p:getInventoryItem(InventorySlotHead)
     if item then
       local paths = findDirectionalPNGs(InventorySlotHead, item:getId())

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -376,8 +376,9 @@ local function nudgeSlotDefault(slotName, dirKey, dx, dy)
   OFFSETS[slotName].default = OFFSETS[slotName].default or {}
   local dk = normalizeDirKey(dirKey)
   local v = OFFSETS[slotName].default[dk] or { 0, 0, true }
-  v[1] = (v[1] or 0) + (dx or 0)
-  v[2] = (v[2] or 0) + (dy or 0)
+  -- screen-based nudge: +x => right, +y => down; stored offsets are subtracted at draw
+  v[1] = (v[1] or 0) - (dx or 0)
+  v[2] = (v[2] or 0) - (dy or 0)
   OFFSETS[slotName].default[dk] = v
   return v
 end
@@ -390,8 +391,9 @@ local function nudgeSlotItem(slotName, itemId, dirKey, dx, dy)
   local key = tostring(itemId)
   OFFSETS[slotName].items[key] = OFFSETS[slotName].items[key] or {}
   local v = OFFSETS[slotName].items[key][dk] or { 0, 0, true }
-  v[1] = (v[1] or 0) + (dx or 0)
-  v[2] = (v[2] or 0) + (dy or 0)
+  -- screen-based nudge: +x => right, +y => down; stored offsets are subtracted at draw
+  v[1] = (v[1] or 0) - (dx or 0)
+  v[2] = (v[2] or 0) - (dy or 0)
   OFFSETS[slotName].items[key][dk] = v
   return v
 end

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -172,6 +172,8 @@ local function switchDirEffect(player, slot, itemId, dirIdx, dirPaths, forceRest
   if forceRestart or not player.getAttachedEffectById or not player:getAttachedEffectById(wantedEffId) then
     local eff = g_attachedEffects.getById(wantedEffId)
     if eff then
+      -- Apply latest offsets at attach time so runtime changes take effect
+      applyOffsetsForAllDirs(eff, slot, itemId)
       player:attachEffect(eff)
       state.activeEffect[slot] = wantedEffId
     end
@@ -341,6 +343,19 @@ end
 function paperdoll_nudge_body(dirKey, dx, dy)
   local v = nudgeSlotDefault('body', dirKey, dx, dy)
   saveOffsets()
+  -- force refresh current attachments to reflect live changes
+  local p = g_game.getLocalPlayer()
+  if p then
+    local dir = p.getDirection and p:getDirection() or South
+    local dirIdx = DIR_INDEX[dir] or 2
+    local item = p:getInventoryItem(InventorySlotBody)
+    if item then
+      local paths = findDirectionalPNGs(InventorySlotBody, item:getId())
+      if next(paths) ~= nil then
+        switchDirEffect(p, InventorySlotBody, item:getId(), dirIdx, paths, true)
+      end
+    end
+  end
   return v
 end
 
@@ -351,6 +366,18 @@ end
 function paperdoll_nudge_head(dirKey, dx, dy)
   local v = nudgeSlotDefault('head', dirKey, dx, dy)
   saveOffsets()
+  local p = g_game.getLocalPlayer()
+  if p then
+    local dir = p.getDirection and p:getDirection() or South
+    local dirIdx = DIR_INDEX[dir] or 2
+    local item = p:getInventoryItem(InventorySlotHead)
+    if item then
+      local paths = findDirectionalPNGs(InventorySlotHead, item:getId())
+      if next(paths) ~= nil then
+        switchDirEffect(p, InventorySlotHead, item:getId(), dirIdx, paths, true)
+      end
+    end
+  end
   return v
 end
 

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -187,6 +187,9 @@ local function switchDirEffect(player, slot, itemId, dirIdx, dirPaths, forceRest
     if eff then
       -- Apply latest offsets at attach time so runtime changes take effect
       applyOffsetsForAllDirs(eff, slot, itemId)
+      -- Ensure effect respects current facing direction for dir-specific offsets
+      local dirConst = INDEX_TO_DIR[dirIdx] or South
+      if eff.setDirection then eff:setDirection(dirConst) end
       player:attachEffect(eff)
       state.activeEffect[slot] = wantedEffId
     end

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -499,6 +499,10 @@ function controller:onGameStart()
         -- While invisible, skip direction switches and inventory re-attach attempts
         return
       end
+      -- Continuously apply latest offsets to all active overlays to reflect live tweaks
+      for s, _ in pairs(state.current) do
+        applyOffsetsToActive(s)
+      end
       local dir = p.getDirection and p:getDirection() or South
       local dirIdx = DIR_INDEX[dir] or 2
       if dirIdx ~= lastDirIdx then

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -127,7 +127,8 @@ local function applyOffsetsToActive(slot)
   local itemId = item and item:getId() or 0
   applyOffsetsForAllDirs(eff, slot, itemId)
   local dir = p.getDirection and p:getDirection() or South
-  if eff.setDirection then eff:setDirection(dir) end
+  local dirResolved = INDEX_TO_DIR[resolveDirIdxForEffect(dir)] or South
+  if eff.setDirection then eff:setDirection(dirResolved) end
 end
 
 local function makeEffectId(slot, itemId, dirIdx)
@@ -454,8 +455,8 @@ function paperdoll_nudge_body(dirKey, dx, dy)
   -- force refresh current attachments to reflect live changes
   local p = g_game.getLocalPlayer()
   if p then
-    local dir = p.getDirection and p:getDirection() or South
-    local dirIdx = DIR_INDEX[dir] or 2
+  local dir = p.getDirection and p:getDirection() or South
+  local dirIdx = resolveDirIdxForEffect(dir)
     -- re-apply offsets directly to active effect to avoid manager resets
     applyOffsetsToActive(InventorySlotBody)
     local item = p:getInventoryItem(InventorySlotBody)
@@ -478,8 +479,8 @@ function paperdoll_nudge_head(dirKey, dx, dy)
   saveOffsets()
   local p = g_game.getLocalPlayer()
   if p then
-    local dir = p.getDirection and p:getDirection() or South
-    local dirIdx = DIR_INDEX[dir] or 2
+  local dir = p.getDirection and p:getDirection() or South
+  local dirIdx = resolveDirIdxForEffect(dir)
     applyOffsetsToActive(InventorySlotHead)
     local item = p:getInventoryItem(InventorySlotHead)
     if item then
@@ -584,7 +585,7 @@ function controller:onGameStart()
         if cid and invisByCreature[cid] then return end
         -- Use creature facing (cardinal), ignore diagonal params
         local dir = p.getDirection and p:getDirection() or South
-        local dirIdx = DIR_INDEX[dir] or 2
+        local dirIdx = resolveDirIdxForEffect(dir)
         -- keep overlays aligned without reattach to avoid flicker/jumps
         for s, itemId in pairs(state.current) do
           local dirPaths = findDirectionalPNGs(s, itemId)
@@ -597,7 +598,7 @@ function controller:onGameStart()
         local cid = p.getId and p:getId() or nil
         if cid and invisByCreature[cid] then return end
         local dir = p.getDirection and p:getDirection() or South
-        local dirIdx = DIR_INDEX[dir] or 2
+        local dirIdx = resolveDirIdxForEffect(dir)
         for s, itemId in pairs(state.current) do
           local dirPaths = findDirectionalPNGs(s, itemId)
           if next(dirPaths) ~= nil then
@@ -616,7 +617,7 @@ function controller:onGameStart()
       -- Continuously apply latest offsets to all active overlays to reflect live tweaks
       for s, _ in pairs(state.current) do applyOffsetsToActive(s) end
       local dir = p.getDirection and p:getDirection() or South
-      local dirIdx = DIR_INDEX[dir] or 2
+      local dirIdx = resolveDirIdxForEffect(dir)
       if dirIdx ~= lastDirIdx then
         for s, itemId in pairs(state.current) do
           local dirPaths = findDirectionalPNGs(s, itemId)

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -152,7 +152,7 @@ local function ensureEffects(slot, itemId, dirPaths)
   end
 end
 
-local function switchDirEffect(player, slot, itemId, dirIdx, dirPaths)
+local function switchDirEffect(player, slot, itemId, dirIdx, dirPaths, forceRestart)
   local wantedEffId = makeEffectId(slot, itemId, dirIdx)
   if not dirPaths[dirIdx] then
     if dirPaths[2] then
@@ -162,14 +162,14 @@ local function switchDirEffect(player, slot, itemId, dirIdx, dirPaths)
     end
   end
   local active = state.activeEffect[slot]
-  if active and active ~= wantedEffId then
+  if active and (active ~= wantedEffId or forceRestart) then
     -- safe detach if API available, otherwise ignore
     if player.detachEffectById then
       player:detachEffectById(active)
     end
     state.activeEffect[slot] = nil
   end
-  if not player.getAttachedEffectById or not player:getAttachedEffectById(wantedEffId) then
+  if forceRestart or not player.getAttachedEffectById or not player:getAttachedEffectById(wantedEffId) then
     local eff = g_attachedEffects.getById(wantedEffId)
     if eff then
       player:attachEffect(eff)
@@ -349,11 +349,11 @@ function controller:onGameStart()
         if cid and invisByCreature[cid] then return end
         local dirIdx = DIR_INDEX[direction] or nil
         if not dirIdx then return end
-        -- increase bounce during step start for a snappier feel
+        -- restart overlay per slot on step start to kick bounce
         for s, itemId in pairs(state.current) do
           local dirPaths = findDirectionalPNGs(s, itemId)
           if next(dirPaths) ~= nil then
-            switchDirEffect(p, s, itemId, dirIdx, dirPaths)
+            switchDirEffect(p, s, itemId, dirIdx, dirPaths, true)
           end
         end
       end,

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -205,7 +205,7 @@ local function ensureEffects(slot, itemId, dirPaths)
   end
 end
 
-local function switchDirEffect(player, slot, itemId, dirIdx, dirPaths, forceRestart)
+local function switchDirEffect(player, slot, itemId, dirIdx, dirPaths, forceRestart, effectDir)
   local wantedEffId = makeEffectId(slot, itemId, dirIdx)
   if not dirPaths[dirIdx] then
     if dirPaths[2] then
@@ -221,7 +221,7 @@ local function switchDirEffect(player, slot, itemId, dirIdx, dirPaths, forceRest
       -- Apply latest offsets at attach time so runtime changes take effect
       applyOffsetsForAllDirs(eff, slot, itemId)
       -- Ensure effect respects current facing direction for dir-specific offsets
-      local dirConst = INDEX_TO_DIR[dirIdx] or South
+      local dirConst = effectDir or (INDEX_TO_DIR[dirIdx] or South)
       if eff.setDirection then eff:setDirection(dirConst) end
       -- attach new first to avoid visual gap, then detach old if needed
       player:attachEffect(eff)
@@ -576,7 +576,7 @@ function controller:onGameStart()
         for s, itemId in pairs(state.current) do
           local dirPaths = findDirectionalPNGs(s, itemId)
           if next(dirPaths) ~= nil then
-            switchDirEffect(p, s, itemId, dirIdx, dirPaths, false)
+            switchDirEffect(p, s, itemId, dirIdx, dirPaths, false, dir)
           end
         end
       end,
@@ -588,7 +588,7 @@ function controller:onGameStart()
         for s, itemId in pairs(state.current) do
           local dirPaths = findDirectionalPNGs(s, itemId)
           if next(dirPaths) ~= nil then
-            switchDirEffect(p, s, itemId, dirIdx, dirPaths, false)
+            switchDirEffect(p, s, itemId, dirIdx, dirPaths, false, dir)
           end
         end
       end

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -308,6 +308,56 @@ function savePaperdollOffsets()
   saveOffsets()
 end
 
+-- Legacy-like console helpers for fine tuning
+local function normalizeDirKey(k)
+  if type(k) ~= 'string' or #k == 0 then return 'S' end
+  local c = k:sub(1,1):upper()
+  if c == 'N' or c == 'E' or c == 'S' or c == 'W' then return c end
+  return 'S'
+end
+
+local function nudgeSlotDefault(slotName, dirKey, dx, dy)
+  loadOffsets()
+  OFFSETS[slotName] = OFFSETS[slotName] or {}
+  OFFSETS[slotName].default = OFFSETS[slotName].default or {}
+  local dk = normalizeDirKey(dirKey)
+  local v = OFFSETS[slotName].default[dk] or { 0, 0, true }
+  v[1] = (v[1] or 0) + (dx or 0)
+  v[2] = (v[2] or 0) + (dy or 0)
+  OFFSETS[slotName].default[dk] = v
+  return v
+end
+
+local function printSlotDefault(slotName)
+  loadOffsets()
+  local m = (OFFSETS[slotName] and OFFSETS[slotName].default) or {}
+  local function fmt(k)
+    local v = m[k] or {0,0,true}
+    return string.format("%s=(%d,%d,%s)", k, v[1] or 0, v[2] or 0, v[3] and 'true' or 'false')
+  end
+  print(string.format("%s offsets: %s %s %s %s", slotName:gsub('^%l', string.upper), fmt('N'), fmt('E'), fmt('S'), fmt('W')))
+end
+
+function paperdoll_nudge_body(dirKey, dx, dy)
+  local v = nudgeSlotDefault('body', dirKey, dx, dy)
+  saveOffsets()
+  return v
+end
+
+function paperdoll_print_body_offsets()
+  printSlotDefault('body')
+end
+
+function paperdoll_nudge_head(dirKey, dx, dy)
+  local v = nudgeSlotDefault('head', dirKey, dx, dy)
+  saveOffsets()
+  return v
+end
+
+function paperdoll_print_head_offsets()
+  printSlotDefault('head')
+end
+
 function controller:onGameStart()
   self:registerEvents(LocalPlayer, {
     onInventoryChange = function(player, slot, item, oldItem)

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -385,6 +385,29 @@ function paperdoll_print_head_offsets()
   printSlotDefault('head')
 end
 
+-- Convenience: nudge according to current facing direction
+local function getCurrentDirKey()
+  local p = g_game.getLocalPlayer()
+  local dir = p and (p.getDirection and p:getDirection() or South) or South
+  return DIR_TO_KEY[dir] or 'S'
+end
+
+function paperdoll_nudge_body_current(dx, dy)
+  local dk = getCurrentDirKey()
+  return paperdoll_nudge_body(dk, dx, dy)
+end
+
+function paperdoll_nudge_head_current(dx, dy)
+  local dk = getCurrentDirKey()
+  return paperdoll_nudge_head(dk, dx, dy)
+end
+
+function paperdoll_print_current_dir()
+  local p = g_game.getLocalPlayer()
+  local dir = p and (p.getDirection and p:getDirection() or South) or South
+  print('current dir:', dir, 'key=', getCurrentDirKey())
+end
+
 function controller:onGameStart()
   self:registerEvents(LocalPlayer, {
     onInventoryChange = function(player, slot, item, oldItem)

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -91,6 +91,18 @@ local function applyOffsetsForAllDirs(eff, slot, itemId)
   applyDir('N'); applyDir('E'); applyDir('S'); applyDir('W')
 end
 
+local function applyOffsetsToActive(slot)
+  local p = g_game.getLocalPlayer()
+  if not p then return end
+  local activeId = state.activeEffect[slot]
+  if not activeId then return end
+  local eff = p.getAttachedEffectById and p:getAttachedEffectById(activeId)
+  if not eff then return end
+  local item = p:getInventoryItem(slot)
+  local itemId = item and item:getId() or 0
+  applyOffsetsForAllDirs(eff, slot, itemId)
+end
+
 local function makeEffectId(slot, itemId, dirIdx)
   return SLOT_BASE[slot] + (itemId % 10000) + (dirIdx or 0)
 end
@@ -297,6 +309,9 @@ function setSlotOffsets(slotName, map)
   loadOffsets()
   OFFSETS[slotName] = OFFSETS[slotName] or {}
   OFFSETS[slotName].default = map
+  -- live apply if current slot matches
+  if slotName == 'head' then applyOffsetsToActive(InventorySlotHead) end
+  if slotName == 'body' then applyOffsetsToActive(InventorySlotBody) end
 end
 
 function setItemOffsets(slotName, itemId, map)
@@ -304,6 +319,8 @@ function setItemOffsets(slotName, itemId, map)
   OFFSETS[slotName] = OFFSETS[slotName] or {}
   OFFSETS[slotName].items = OFFSETS[slotName].items or {}
   OFFSETS[slotName].items[tostring(itemId)] = map
+  if slotName == 'head' then applyOffsetsToActive(InventorySlotHead) end
+  if slotName == 'body' then applyOffsetsToActive(InventorySlotBody) end
 end
 
 function savePaperdollOffsets()


### PR DESCRIPTION
Summary
Sincroniza overlays com movimento (onWalk/onAutoWalk) e ciclo de 100ms.
Corrige direção em diagonais mapeando para cardinais (NE/SE→E, NW/SW→W).
Remove flicker (anexa novo antes de remover antigo; sem restart na troca de direção).
Mantém invisibilidade estável (oculta em todo o ciclo).
Calibração ao vivo (por slot e por item) com persistência em /settings/paperdoll_offsets.json.
Blending automático de offsets nas diagonais e aplicação contínua a cada tick.
Helpers de console:
Por slot: paperdoll_nudge_body('N|E|S|W', dx, dy), paperdoll_print_body_offsets()
Por direção atual: paperdoll_nudge_body_current(dx, dy), paperdoll_print_current_dir()
Por item (equipped): paperdoll_nudge_body_item('N|E|S|W', dx, dy), paperdoll_print_body_item_offsets(), paperdoll_clear_body_item_offsets() 

Test plan
Logar, equipar head/body (10385/10384).
Andar em todas as direções; diagonais não devem “cair” para S.
Alternar direção rápido; sem “pulo” perceptível.
Ativar/desativar invisibilidade; overlays ocultam/mostram sem erro.
Usar helpers para ajustar offsets; mudanças refletem imediatamente.
Notes
Bounce é opcional (desativado por padrão); pode ser habilitado facilmente no código.
Offsets salvos em JSON para versionar no futuro, se desejado.
