### PR TITLE
Continue otclient calibration offset window development

### DIFF
--- a/modules/game_paperdoll_overlay/paperdoll_calibration.otui
+++ b/modules/game_paperdoll_overlay/paperdoll_calibration.otui
@@ -1,0 +1,168 @@
+UIWindow
+  id: paperdollCalibrationWindow
+  text: Paperdoll Calibration
+  anchors.centerIn: parent
+  size: 380 240
+  visible: false
+
+  UIWidget
+    id: content
+    anchors.fill: parent
+    layout:
+      type: verticalBox
+      spacing: 6
+    padding: 6
+
+    UIWidget
+      id: topRow
+      layout:
+        type: horizontalBox
+        spacing: 6
+      height: 24
+
+      ComboBox
+        id: slotCombo
+        size: 120 20
+        @onOptionChange: modules.game_paperdoll_overlay.calibration.onSlotChange()
+
+      CheckBox
+        id: perItem
+        !text: tr("Per item")
+        @onCheckChange: modules.game_paperdoll_overlay.calibration.onPerItemToggle(self:isChecked())
+
+      Button
+        id: useCurrentDir
+        text: Use current dir
+        @onClick: modules.game_paperdoll_overlay.calibration.useCurrentDir()
+
+      Label
+        id: dirLabel
+        text: Direction: S
+        anchors.right: parent.right
+
+    UIWidget
+      id: dirRow
+      layout:
+        type: horizontalBox
+        spacing: 6
+      height: 24
+
+      Button
+        text: N
+        width: 32
+        @onClick: modules.game_paperdoll_overlay.calibration.setDir('N')
+
+      Button
+        text: E
+        width: 32
+        @onClick: modules.game_paperdoll_overlay.calibration.setDir('E')
+
+      Button
+        text: S
+        width: 32
+        @onClick: modules.game_paperdoll_overlay.calibration.setDir('S')
+
+      Button
+        text: W
+        width: 32
+        @onClick: modules.game_paperdoll_overlay.calibration.setDir('W')
+
+      UIWidget
+        size: 10 1
+        phantom: true
+
+      Label
+        text: Step:
+
+      SpinBox
+        id: step
+        width: 60
+        minimum: 1
+        maximum: 50
+        value: 1
+
+      Label
+        id: itemIdLabel
+        text: Item ID: 0
+        anchors.right: parent.right
+
+    UIWidget
+      id: arrowsRow
+      layout:
+        type: verticalBox
+        spacing: 4
+
+      UIWidget
+        layout:
+          type: horizontalBox
+          spacing: 6
+        height: 28
+
+        UIWidget
+          width: 40
+          phantom: true
+
+        Button
+          id: upBtn
+          text: 
+          !text: tr("▲")
+          width: 40
+          @onClick: modules.game_paperdoll_overlay.calibration.onArrow('up')
+
+      UIWidget
+        layout:
+          type: horizontalBox
+          spacing: 6
+        height: 28
+
+        Button
+          id: leftBtn
+          text: 
+          !text: tr("◀")
+          width: 40
+          @onClick: modules.game_paperdoll_overlay.calibration.onArrow('left')
+
+        UIWidget
+          width: 40
+          phantom: true
+
+        Button
+          id: rightBtn
+          text: 
+          !text: tr("▶")
+          width: 40
+          @onClick: modules.game_paperdoll_overlay.calibration.onArrow('right')
+
+      UIWidget
+        layout:
+          type: horizontalBox
+          spacing: 6
+        height: 28
+
+        UIWidget
+          width: 40
+          phantom: true
+
+        Button
+          id: downBtn
+          text: 
+          !text: tr("▼")
+          width: 40
+          @onClick: modules.game_paperdoll_overlay.calibration.onArrow('down')
+
+    UIWidget
+      id: actionsRow
+      layout:
+        type: horizontalBox
+        spacing: 6
+      height: 30
+
+      Button
+        id: saveBtn
+        text: Save
+        @onClick: modules.game_paperdoll_overlay.calibration.save()
+
+      Button
+        id: clearItemBtn
+        text: Clear Item Override
+        @onClick: modules.game_paperdoll_overlay.calibration.clearItem()

--- a/modules/game_paperdoll_overlay/paperdoll_overlay.lua
+++ b/modules/game_paperdoll_overlay/paperdoll_overlay.lua
@@ -544,6 +544,69 @@ function paperdoll_clear_body_item_offsets()
   saveOffsets(); updateManagerConfigFor(InventorySlotBody, it:getId()); applyOffsetsToActive(InventorySlotBody)
 end
 
+-- Head item-specific calibration helpers (symmetrical to body)
+function paperdoll_nudge_head_item(dirKey, dx, dy)
+  local p = g_game.getLocalPlayer(); if not p then return end
+  local it = p:getInventoryItem(InventorySlotHead); if not it then return end
+  local v = nudgeSlotItem('head', it:getId(), dirKey, dx, dy)
+  saveOffsets(); updateManagerConfigFor(InventorySlotHead, it:getId()); applyOffsetsToActive(InventorySlotHead)
+  return v
+end
+
+function paperdoll_print_head_item_offsets()
+  local p = g_game.getLocalPlayer(); if not p then return end
+  local it = p:getInventoryItem(InventorySlotHead); if not it then return end
+  printSlotItem('head', it:getId())
+end
+
+function paperdoll_clear_head_item_offsets()
+  loadOffsets()
+  local p = g_game.getLocalPlayer(); if not p then return end
+  local it = p:getInventoryItem(InventorySlotHead); if not it then return end
+  local key = tostring(it:getId())
+  if OFFSETS.head and OFFSETS.head.items then OFFSETS.head.items[key] = nil end
+  saveOffsets(); updateManagerConfigFor(InventorySlotHead, it:getId()); applyOffsetsToActive(InventorySlotHead)
+end
+
+-- Small exported helpers for UI integration
+function paperdoll_get_current_dir_key()
+  return getCurrentDirKey()
+end
+
+function paperdoll_save_offsets()
+  saveOffsets()
+end
+
+local function resolveSlotConstByName(slotName)
+  if slotName == 'head' then return InventorySlotHead end
+  if slotName == 'body' then return InventorySlotBody end
+  if slotName == 'back' then return InventorySlotBack end
+  if slotName == 'left' then return InventorySlotLeft end
+  if slotName == 'right' then return InventorySlotRight end
+  if slotName == 'legs' then return InventorySlotLeg end
+  if slotName == 'feet' then return InventorySlotFeet end
+  if slotName == 'neck' then return InventorySlotNeck end
+  if slotName == 'finger' then return InventorySlotFinger end
+  if slotName == 'ammo' then return InventorySlotAmmo end
+  if slotName == 'purse' then return InventorySlotPurse end
+  return nil
+end
+
+function paperdoll_refresh_slot(slotName)
+  local slot = resolveSlotConstByName(slotName)
+  if not slot then return end
+  applyOffsetsToActive(slot)
+end
+
+function paperdoll_get_active_item_id(slotName)
+  local slot = resolveSlotConstByName(slotName)
+  if not slot then return 0 end
+  local p = g_game.getLocalPlayer(); if not p then return 0 end
+  local it = p:getInventoryItem(slot); if not it then return 0 end
+  return it:getId()
+end
+
+
 function controller:onGameStart()
   self:registerEvents(LocalPlayer, {
     onInventoryChange = function(player, slot, item, oldItem)


### PR DESCRIPTION
Add paperdoll offset calibration helpers and UI window to enable visual adjustment of item positions.

---
<a href="https://cursor.com/background-agent?bcId=bc-a419fe02-259a-4fe1-ae66-01cc1f849aaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a419fe02-259a-4fe1-ae66-01cc1f849aaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

